### PR TITLE
Repair overlapping-search-terms bug in ThreadJoinTest

### DIFF
--- a/ThreadJoinTest/src/ThreadJoinTest.java
+++ b/ThreadJoinTest/src/ThreadJoinTest.java
@@ -22,7 +22,7 @@ public class ThreadJoinTest {
      * the words concurrently in multiple threads.
      */
     private final static String[] mOneShotInputStrings = 
-    {"xreo", "xfao", "xmiomio", "xlao", "xtiotio", "xsoosoo", "xdoo", "xdoodoo"};
+    {"xreo", "xfao", "xmiomio", "xlao", "xtiotio", "xsoosoo", "xdoo", "xdoodoooo"};
 
     // List of words to search for.
     private static String[] mWordList = {"do",
@@ -32,7 +32,8 @@ public class ThreadJoinTest {
                                          "so",
                                          "la",
                                          "ti",
-                                         "do"};
+                                         "do",
+                                         "oo"};
         
     /**
      * @class SearchOneShotThreadGangJoin
@@ -127,7 +128,7 @@ public class ThreadJoinTest {
                 // appears in the input data.
                 for (int i = inputData.indexOf(word, 0);
                      i != -1;
-                     i = inputData.indexOf(word, i + word.length()))
+                     i = inputData.indexOf(word, i + 1))
                     // Each time a match is found the processResults()
                     // hook method is called to handle the results.
                     processResults("in thread " 


### PR DESCRIPTION
Hi Douglas,
This pull request resolves a hidden bug in ThreadJoinTest. Not the concurrency is wrong, but the word search: it does not handle search terms that could overlap.
Lines 25 and 36 add test data uncovering the bug.
Line 130 contains the solution.
You might only take solution on board (as test data is not as clean anymore).

Best regards, Kees

PS: Found this will doing the MOOC "Programming Mobile Services for Android Handheld Systems: Concurrency". This LiveLesson is mentioned in Java Threads pt1.
