### PR TITLE
Some minor edits that you can review and cherry pick from.

### DIFF
--- a/ImageStreamGangApp/app/build.gradle
+++ b/ImageStreamGangApp/app/build.gradle
@@ -29,7 +29,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:support-v4:23.1.1'
-    compile 'com.android.support:design:23.1.1'
+    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:support-v4:24.0.0'
+    compile 'com.android.support:design:24.0.0'
 }

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/activities/MainActivity.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/activities/MainActivity.java
@@ -166,9 +166,7 @@ public class MainActivity
         // Check to see if the user entered any lists.
         if (iterator != null) {
             if (iterator.hasNext() 
-                && (inputSource == Options.InputSource.USER
-                    ? !isEmpty() 
-                    : true)) 
+                && (inputSource != Options.InputSource.USER || !isEmpty()))
                 new Thread(makeImageStream(mFilters,
                                            iterator,
                                            mCompletionHook)).start();

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/filters/Filter.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/filters/Filter.java
@@ -25,8 +25,8 @@ public abstract class Filter {
      * Constructs the filter with the default name.
      */
     public Filter() {
-    	String baseName = this.getClass().getCanonicalName();
-        mName = baseName.substring(baseName.lastIndexOf(".") + 1);
+        // Default uses the class name without the package prefix.
+    	mName = this.getClass().getSimpleName();
     }
 
     /**

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/ImageStreamCompletableFuture1.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/ImageStreamCompletableFuture1.java
@@ -6,57 +6,57 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import livelessons.imagestreamgang.filters.Filter;
 import livelessons.imagestreamgang.utils.Image;
-import livelessons.imagestreamgang.utils.NetUtils;
 
 /**
- * Customizes ImageStream to use Java 8 CompletableFutures to
- * download, process, and store images concurrently.
+ * Customizes ImageStream to use Java 8 CompletableFutures to download, process,
+ * and store images concurrently.
  */
 public class ImageStreamCompletableFuture1
-       extends ImageStream {
+        extends ImageStream {
     /**
      * Constructor initializes the superclass and data members.
      */
-    public ImageStreamCompletableFuture1(Filter[] filters,
-                                        Iterator<List<URL>> urlListIterator,
-                                        Runnable completionHook) {
+    public ImageStreamCompletableFuture1(
+            Filter[] filters,
+            Iterator<List<URL>> urlListIterator,
+            Runnable completionHook) {
         super(filters, urlListIterator, completionHook);
     }
 
     /**
-     * Perform the ImageStream processing, which uses Java 8
-     * CompletableFutures to download, process, and store images
-     * concurrently.
+     * Perform the ImageStream processing, which uses Java 8 CompletableFutures
+     * to download, process, and store images concurrently.
      */
     @Override
     protected void processStream() {
-        getInput()
-            // Concurrently process each URL in the input List.
-            .parallelStream()
+        List<Image> collect = getInput()
+                // Concurrently process each URL in the input List.
+                .parallelStream()
 
-            // Filter out URLs that are already cached.
-            .filter(this::urlNotCached)
+                // Only include URLs that have not been already cached.
+                .filter(not(this::urlCached))
 
-            // Submit the URLs for asynchronous downloading.
-            .map(url ->
-                 CompletableFuture.supplyAsync(() ->
-                                               makeImage(url),
-                                               getExecutor()))
-            // Wait for all async operations to finish.
-            .map(CompletableFuture::join)
+                // Submit the URLs for asynchronous downloading.
+                .map(this::makeImageAsync)
 
-            // Map each image to a stream containing the filtered
-            // versions of the image.
-            .flatMap(this::applyFilters)
+                // Wait for all async operations to finish.
+                .map(CompletableFuture::join)
 
-            // Terminate the stream.
-            .collect(Collectors.toList());
+                // Map each image to a stream containing the filtered
+                // versions of the image.
+                .flatMap(this::applyFilters)
+
+                // Terminate the stream.
+                .collect(Collectors.toList());
+
+        Log.d(TAG, "processing of "
+                + (collect != null ? collect.size() : "0")
+                + " image(s) is complete");
     }
 
     /**
@@ -64,16 +64,26 @@ public class ImageStreamCompletableFuture1
      */
     private Stream<Image> applyFilters(Image image) {
         return mFilters.parallelStream()
-            // Create a FilterDecoratorWithImage for each filter/image
-            // combo.
-            .map(filter -> makeFilterDecoratorWithImage(filter, image))
+                // Create a FilterDecoratorWithImage for each filter/image
+                // combo.
+                .map(filter -> makeFilterDecoratorWithImage(filter, image))
 
-            // Asynchronously filter the image and store it in an
-            // output file.
-            .map(decoratedFilterWithImage -> 
-                 CompletableFuture.supplyAsync(decoratedFilterWithImage::run,
-                                               getExecutor()))
-            // Wait for all async operations to finish.
-            .map(CompletableFuture::join);
+                // Asynchronously filter the image and store it in an
+                // output file.
+                .map(decoratedFilterWithImage ->
+                             CompletableFuture.supplyAsync(
+                                     decoratedFilterWithImage::run,
+                                     getExecutor()))
+                // Wait for all async operations to finish.
+                .map(CompletableFuture::join);
+    }
+
+    /**
+     * Asynchronously download an Image from the @a url parameter.
+     */
+    private CompletableFuture<Image> makeImageAsync(URL url) {
+        // Asynchronously download an Image from the url parameter.
+        return CompletableFuture.supplyAsync(() -> makeImage(url),
+                                             getExecutor());
     }
 }

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/ImageStreamCompletableFuture2.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/ImageStreamCompletableFuture2.java
@@ -1,19 +1,11 @@
 package livelessons.imagestreamgang.streams;
 
-import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.util.Log;
 
 import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.function.IntFunction;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import livelessons.imagestreamgang.filters.Filter;
 import livelessons.imagestreamgang.filters.FilterDecoratorWithImage;
@@ -48,8 +40,8 @@ public class ImageStreamCompletableFuture2
             // Concurrently process each URL in the input List.
             .parallelStream()
 
-            // Filter out URLs that are already cached.
-            .filter(this::urlNotCached)
+            // Only include URLs that have not been already cached.
+            .filter(not(this::urlCached))
 
             // Submit non-cached URLs for asynchronous downloading,
             // which returns a stream of unfiltered Image futures.
@@ -62,7 +54,7 @@ public class ImageStreamCompletableFuture2
             .map(imageFuture ->
                  imageFuture.thenApply(this::makeFilterDecoratorsWithImage))
 
-            // After each future completes the compose the results
+            // After each future completes then compose the results
             // with the applyFiltersAsync() method, which returns a
             // list of filtered Image futures.
             .map(listFilterDecoratorsFuture ->

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/ImageStreamParallel.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/ImageStreamParallel.java
@@ -1,11 +1,8 @@
 package livelessons.imagestreamgang.streams;
 
-import android.util.Log;
-
 import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -34,7 +31,7 @@ public class ImageStreamParallel
 
     /**
      * Perform the ImageStream processing, which uses a Java 8
-     * parallelstream to download, process, and store images
+     * parallel stream to download, process, and store images
      * concurrently.
      */
     @Override
@@ -43,8 +40,8 @@ public class ImageStreamParallel
             // Concurrently process each URL in the input List.
             .parallelStream()
 
-            // Filter out URLs that are already cached.
-            .filter(this::urlNotCached)
+            // Only include URLs that have not been already cached.
+            .filter(not(this::urlCached))
 
             // Transform URL -> Image (download each image via
             // its URL).

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/ImageStreamSequential.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/ImageStreamSequential.java
@@ -1,11 +1,8 @@
 package livelessons.imagestreamgang.streams;
 
-import android.util.Log;
-
 import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 import livelessons.imagestreamgang.filters.Filter;
 import livelessons.imagestreamgang.filters.FilterDecoratorWithImage;
@@ -36,37 +33,37 @@ public class ImageStreamSequential
             // Sequentially process each URL in the input List.
             .stream()
 
-            // Filter out URLs that are already cached.
-            .filter(this::urlNotCached)
+            // Only include URLs that have not been already cached.
+            .filter(not(this::urlCached))
 
             // Transform URL -> Image (download each image via
             // its URL).
             .map(this::makeImage)
 
-            // Each all filters to each image sequentially (similar to
+            // Apply all filters to each image sequentially (similar to
             // a nested for loop).
             .forEach(this::applyFilters);
     }
 
     /**
-     * @return false if the @a url is already in the cache, else true;
+     * @return true if the @a url is already in the cache, else false.
      */
     @Override
-    protected boolean urlNotCached(URL url) {
+    protected boolean urlCached(URL url) {
         // Iterate through the list of filters and sequentially check
         // to see which ones are already cached.
         long count = mFilters
             .stream()
             .filter(filter ->
-                    urlNotCached(url, filter.getName()))
+                    urlCached(url, filter.getName()))
             .count();
 
-        // A count > 0 means the url was not already in the cache.
+        // A count > 0 means the url has already been cached.
         return count > 0;
     }
 
     /**
-     * Apply the filters to each @a image sequencially.
+     * Apply the filters to each @a image sequentially.
      */
     private void applyFilters(Image image) {
         mFilters

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/StreamGang.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/streams/StreamGang.java
@@ -99,7 +99,7 @@ public abstract class StreamGang<E>
         // Invoke hook method to get initial List of input data to
         // process.
         if (setInput(getNextInput()) != null) {
-            // Invoke hook method to initate Stream processing.
+            // Invoke hook method to initiate Stream processing.
             initiateStream();
 
             // Invoke hook method to wait for all the tasks to exit.

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/utils/FutureUtils.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/utils/FutureUtils.java
@@ -2,7 +2,6 @@ package livelessons.imagestreamgang.utils;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import livelessons.imagestreamgang.streams.ImageStreamCompletableFuture2;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -13,7 +12,7 @@ public class FutureUtils {
      * Waits for all of the CompletableFutures in @a futures to finish
      * and then returns a CompletableFuture containing a List with all
      * the results.
-     * @param futures
+     * @param futures A list of completable futures.
      */
     public static <T> CompletableFuture<List<T>> joinAll(List<CompletableFuture<T>> futures) {
         CompletableFuture<Void> allDoneFuture =

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/utils/NetUtils.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/utils/NetUtils.java
@@ -1,7 +1,5 @@
 package livelessons.imagestreamgang.utils;
 
-import android.util.Log;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,7 +37,7 @@ public final class NetUtils {
         
         // Creates an InputStream from the inputUrl from which to read
     	// the image data.
-        try (InputStream istream = (InputStream) url.openStream()) {
+        try (InputStream istream = url.openStream()) {
             // While there is unread data from the inputStream,
             // continue writing data to the byte array.
             while ((bytes = istream.read(readBuffer)) > 0) 

--- a/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/utils/PermissionRequest.java
+++ b/ImageStreamGangApp/app/src/main/java/livelessons/imagestreamgang/utils/PermissionRequest.java
@@ -180,7 +180,7 @@ public class PermissionRequest {
     /**
      * Uses either Snackbar or Toast depending on snackbar snackbar setting.
      *
-     * @param id
+     * @param id A string resource to display.
      */
     @MainThread
     private void showMessage(@StringRes int id) {

--- a/ImageStreamGangApp/app/src/main/res/layout/results_activity.xml
+++ b/ImageStreamGangApp/app/src/main/res/layout/results_activity.xml
@@ -16,7 +16,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:gravity="left" />
+            android:gravity="start" />
         
     </HorizontalScrollView>
    

--- a/ImageStreamGangApp/app/src/main/res/values/permissions.xml
+++ b/ImageStreamGangApp/app/src/main/res/values/permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Default permission strings -->
-    <string name="permission_rationale" formatted="false">This activity requires the following permissions: %1$s</string>
+    <string name="permission_rationale" formatted="false">This activity requires the following permissions: %s</string>
     <string name="permissions_granted">Permissions were granted.</string>
     <string name="permissions_denied">Permissions were not granted.</string>
     <string name="permissions_ok_button">OK</string>

--- a/ImageStreamGangApp/build.gradle
+++ b/ImageStreamGangApp/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ImageStreamGangApp/gradle.properties
+++ b/ImageStreamGangApp/gradle.properties
@@ -16,3 +16,6 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# Android Studio suggested memory size for Jack tool-chain compiling.
+org.gradle.jvmargs=-Xmx1536M


### PR DESCRIPTION
Some minor lint issues fixed.

Upgraded gradle build to latest wrapper and increased Jack tool-chain memory for compiling.

.collect(Collectors.toList()) call in ImageStreamCompletableFuture1 didn't really make sense unless the  entire chain returns the list ... so I added that and then simply used it to print out the count of images like in the other example solutions. Perhaps I'm wrong and you need the .collect() even though you don't use it's result, but I could not find anywhere in the documentation that says it's mandatory...

I found the .filter(this:notUrlCached) to be confusing particularly when I went to read this "negative" function implementation. So I wanted to see if you think it might be clearer to use a "not" predicate instead. I will understand if you don't like it, but I thought it made the code a wee bit more readable.

