### PR TITLE
Change sleep time for main thread before interrupting thr to 2 seconds

### DIFF
--- a/UserThreadInterrupted/src/TestInterrupted.java
+++ b/UserThreadInterrupted/src/TestInterrupted.java
@@ -37,8 +37,8 @@ public class TestInterrupted {
 
         try {
             if(interruptThread) {
-                // Sleep for 4 seconds and then interrupt the Thread.
-                Thread.sleep(4000);
+                // Sleep for 2 seconds and then interrupt the Thread.
+                Thread.sleep(2000);
 
                 System.out.println("interrupting thread " 
                                    + thr.getName());


### PR DESCRIPTION
Hi, 
I noticed that the sleep time in the main thread of this project allows enough time for the iterations to complete and hence the other thread terminates before getting interrupted. 
I noticed this in my machine and also on the demo of one of the videos of the LiveLessons training.
The video name is " Understand the Java Thread lifecycle and how to manage it effectively" from Java Concurrency LiveLessons video training. 
This is probably nitpicking but i thought it would be much better if the program runs correctly every time.

Regards,
Sankalp