### PR TITLE
IterativeForkJoin - gradle upgrade

### DIFF
--- a/SearchForkJoin/IterativeForkJoin/build.gradle
+++ b/SearchForkJoin/IterativeForkJoin/build.gradle
@@ -11,5 +11,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    // https://mvnrepository.com/artifact/junit/junit
+    testImplementation group: 'junit', name: 'junit', version: '4.11'
+
 }

--- a/SearchForkJoin/IterativeForkJoin/gradle/wrapper/gradle-wrapper.properties
+++ b/SearchForkJoin/IterativeForkJoin/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
Just updates the gradle version. I had to do this to run the app in intellij 2020.3