### PR TITLE
Fix compile error

### DIFF
--- a/ImageStreamGang/CommandLine/src/main/java/livelessons/streams/ImageStreamReactor1.java
+++ b/ImageStreamGang/CommandLine/src/main/java/livelessons/streams/ImageStreamReactor1.java
@@ -4,6 +4,7 @@ import livelessons.filters.Filter;
 import livelessons.utils.Image;
 import livelessons.utils.ReactorUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 import java.net.URL;
 import java.util.ArrayList;

--- a/ImageStreamGang/CommandLine/src/main/java/livelessons/streams/ImageStreamReactor2.java
+++ b/ImageStreamGang/CommandLine/src/main/java/livelessons/streams/ImageStreamReactor2.java
@@ -4,6 +4,7 @@ import livelessons.filters.Filter;
 import livelessons.utils.Image;
 import livelessons.utils.ReactorUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 import java.net.URL;
 import java.util.Iterator;
@@ -40,13 +41,13 @@ public class ImageStreamReactor2
 
         List<Image> filteredImages = Flux
             // Convert collection into a flux.
-            .fromIterable(iterable)
+            .fromIterable(urls)
 
             // Create a parallel flux.
             .parallel()
 
             // Run this flow of operations in the elastic thread pool.
-            .runOn(Schedulers.boundedElastic());
+            .runOn(Schedulers.boundedElastic())
 
             // Use filter() to ignore URLs that are already cached
             // locally, i.e., only download non-cached images.

--- a/RxJava/ex1/src/main/java/ex1.java
+++ b/RxJava/ex1/src/main/java/ex1.java
@@ -37,7 +37,7 @@ public class ex1 {
     */
     public static void main(String[] args) {
         // Run the test program.
-        new ex5().run();
+        new ex1().run();
     }
 
     /**

--- a/RxJava/ex4/src/main/java/ImageCounter.java
+++ b/RxJava/ex4/src/main/java/ImageCounter.java
@@ -7,6 +7,7 @@ import utils.RxUtils;
 import java.util.concurrent.ConcurrentHashMap;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap.KeySetView;
 
 /**
  * This class concurrently counts the number of images in a


### PR DESCRIPTION
- It is ex1 project in RxJava folder.
It is suppoed to call the constructor of ex1, not of ex5.

- Add import to KeySetView class to be compiled successfully.

- Add import to Schedulers class and fix syntax error to be compiled successfully.