### PR TITLE
Upgrade gradle version to 4.8.1

### DIFF
--- a/BusySynchronizedQueue/gradle/wrapper/gradle-wrapper.properties
+++ b/BusySynchronizedQueue/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip

--- a/Folders/Async/src/main/java/folder/BFSFolderSpliterator.java
+++ b/Folders/Async/src/main/java/folder/BFSFolderSpliterator.java
@@ -3,12 +3,14 @@ package folder;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
 
 /**
- * In conjunction with {@link StreamSupport.stream()} and {@link
- * Spliterators.spliterator()} this class creates a sequential or
+ * In conjunction with {@link StreamSupport#stream} and {@link
+ * Spliterators#spliterator} this class creates a sequential or
  * parallel stream of {@link Dirent} objects from a
  * recursively-structured directory folder.
  */

--- a/Folders/Async/src/main/java/folder/Folder.java
+++ b/Folders/Async/src/main/java/folder/Folder.java
@@ -79,7 +79,7 @@ public class Folder
     }
 
     /**
-     * @return A {@link spliterator} for this {@link Folder}
+     * @return A {@link Spliterator} for this {@link Folder}
      */
     public Spliterator<Dirent> spliterator() {
         // Create a spliterator that uses breadth-first search to


### PR DESCRIPTION
1. This BusySynchronizedQueue uses Gradle version 3.0, with which I could not build successfully.
Other projects like BuggyQueue, DeadlockQueue use Gradle version 4.8.1.
So, I upgraded Gradle version to 4.8.1 and it works well.

* Gradle Sync error message (with Gradle version 3.0)
```java
Unable to find method 'org.gradle.api.invocation.Gradle.getIncludedBuilds()Ljava/util/Collection;'
org.gradle.api.invocation.Gradle.getIncludedBuilds()Ljava/util/Collection;

Gradle's dependency cache may be corrupt (this sometimes occurs after a network connection timeout.)

Re-download dependencies and sync project (requires network)
The state of a Gradle build process (daemon) may be corrupt. Stopping all Gradle daemons may solve this problem.

Stop Gradle build processes (requires restart)
Your project may be using a third-party plugin which is not compatible with the other plugins in the project or the version of Gradle requested by the project.

In the case of corrupt Gradle processes, you can also try closing the IDE and then killing all Java processes.
```

2. Make Javadoc link tag to reference the right class and method.