### PR TITLE
Fix semantic errors and upgrade the version of Gradle and Android Gradle Plugin

### DIFF
--- a/ImageStreamGang/AndroidGUI/app/build.gradle
+++ b/ImageStreamGang/AndroidGUI/app/build.gradle
@@ -25,9 +25,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
-    compile 'com.android.support:support-annotations:26.1.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:design:26.1.0'
+    implementation 'com.android.support:support-annotations:26.1.0'
 }

--- a/ImageStreamGang/AndroidGUI/build.gradle
+++ b/ImageStreamGang/AndroidGUI/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ImageStreamGang/AndroidGUI/gradle/wrapper/gradle-wrapper.properties
+++ b/ImageStreamGang/AndroidGUI/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip

--- a/ImageStreamGang/CommandLine/src/main/java/livelessons/ImageStreamGangTest.java
+++ b/ImageStreamGang/CommandLine/src/main/java/livelessons/ImageStreamGangTest.java
@@ -133,12 +133,12 @@ public class ImageStreamGangTest {
                 return new ImageStreamRxJava2(filters,
                                               urlIterator);
         case REACTOR1:
-                return new ImageStreamRxJava2(filters,
-                                              urlIterator);
+                return new ImageStreamReactor1(filters,
+                                               urlIterator);
 
         case REACTOR2:
-                return new ImageStreamRxJava2(filters,
-                                              urlIterator);
+                return new ImageStreamReactor2(filters,
+                                               urlIterator);
         }
         return null;
     }

--- a/ImageStreamGang/SpringWeb/src/main/java/livelessons/ImageStreamGangTest.java
+++ b/ImageStreamGang/SpringWeb/src/main/java/livelessons/ImageStreamGangTest.java
@@ -133,12 +133,12 @@ public class ImageStreamGangTest {
                 return new ImageStreamRxJava2(filters,
                                               urlIterator);
         case REACTOR1:
-                return new ImageStreamRxJava2(filters,
-                                              urlIterator);
+                return new ImageStreamReactor1(filters,
+                                               urlIterator);
 
         case REACTOR2:
-                return new ImageStreamRxJava2(filters,
-                                              urlIterator);
+                return new ImageStreamReactor2(filters,
+                                               urlIterator);
         }
         return null;
     }


### PR DESCRIPTION
### **1. Fix semantic errors**
Use ImageStreamReactor1 and Reactor2 implementation in ImageStreamGang factory method.

### **2. Upgrade the version of Gradle and Android Gradle Plugin**
I tried to build the Android project of ImageStreamGang, but it failed.
Android Studio (Giraffe 2022.3.1) requires at least the version 3.2 of Android Gradle Plugin.
Thus, I upgraded the version of Android Gradle Plugin to 7.3.1 along with Gradle to 7.5.1.
(Each version of Android Gradle Plugin has the minimum required Gradle version.)

Reference: https://developer.android.com/studio/releases/gradle-plugin

Thank you ^0^