### PR TITLE
Call factorial in BuggyFactorial2

### DIFF
--- a/Java8/ex12/src/main/java/tests/CollectTests.java
+++ b/Java8/ex12/src/main/java/tests/CollectTests.java
@@ -2,6 +2,10 @@ package tests;
 
 import utils.Utils;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.TreeMap;
 import java.util.stream.Collector;
 
 import static java.util.function.Function.identity;

--- a/Java8/ex16/src/main/java/ex16.java
+++ b/Java8/ex16/src/main/java/ex16.java
@@ -74,7 +74,7 @@ public class ex16 {
                 n);
 
         runTest("BuggyFactorial2",
-                BuggyFactorial1::factorial,
+                BuggyFactorial2::factorial,
                 n);
 
         runTest("SynchronizedParallelFactorial",

--- a/Java8/ex18/src/main/java/ex18.java
+++ b/Java8/ex18/src/main/java/ex18.java
@@ -213,7 +213,7 @@ public class ex18 {
     }
 
     /**
-     * Test the {@link StreamsUtils.joinAll()} method.
+     * Test the {@link StreamsUtils#joinAll} method.
      */
     private static void testJoinAll
         (List<Function<BigInteger, BigInteger>> factList,

--- a/Java8/ex8/src/main/java/ex8.java
+++ b/Java8/ex8/src/main/java/ex8.java
@@ -3,6 +3,7 @@ import tests.MultiTriggerTests;
 import tests.SingleTriggerTests;
 import tests.ThreadTests;
 import utils.AsyncTester;
+import utils.BigFraction;
 
 import java.util.concurrent.CompletableFuture;
 


### PR DESCRIPTION
1. Call factorial in BuggyFactorial2,
instead of calling factorial in BuggyFactorial1 twice (Semantic error) 

2. Add Imports for Javadoc reference

3. Use the hash character for the class member in Javadoc

Always thanks for sharing high quality knowledge, prof. Doug :)

#### Additionally, in LiveLessons\Java8\ex13\src\ex13.java, I found that there is the function call to showRegexSearch(bardQuote) but there is no implementation of it.