### PR TITLE
Use interface for DI, and else..

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,9 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+# Eclipse projects related
+.project
+.classpath
+.settings/
+
+

--- a/WebFlux/ex1/Dockerfile
+++ b/WebFlux/ex1/Dockerfile
@@ -1,0 +1,17 @@
+FROM amd64/gradle:8.0.1-jdk19-alpine as builder
+
+ADD ./build.gradle /home/gradle/build.gradle
+ADD ./src /home/gradle/src/
+
+RUN gradle build -x test
+
+
+
+FROM amazoncorretto:19-alpine-jdk
+
+# copy jar from builder stage
+COPY --from=builder /home/gradle/build/libs/*.jar app.jar
+
+EXPOSE 8080 8080
+
+CMD ["sh", "-c", "java --enable-preview -jar app.jar " ]

--- a/WebFlux/ex1/jsclients/callerpage.html
+++ b/WebFlux/ex1/jsclients/callerpage.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fetch API Example</title>
+</head>
+<body>
+
+  <button onclick="callMonoApi()">Call Mono API</button>
+  <textarea id="monoResult" rows="10" cols="50"></textarea>
+
+  <br><br>
+   <input type="text" id="paramInput" placeholder="Enter lockManagerName name">
+     <br><br>
+  <button onclick="callFluxApi()">Call Flux API</button>
+  <textarea id="fluxResult" rows="10" cols="50"></textarea>
+
+  <script>
+    function callMonoApi() {
+      
+
+      const monoUrl = `http://localhost:8080/create?permitCount=3`;
+
+      fetch(monoUrl)
+        .then(response => response.json())
+        .then(data => {
+          document.getElementById('monoResult').value = JSON.stringify(data, null, 2);
+        })
+        .catch(error => {
+          console.error('Error calling Mono API:', error);
+        });
+    }
+
+    function callFluxApi() {
+      const paramInput = document.getElementById('paramInput').value;
+      const fluxUrl = `http://localhost:8080/acquireLocksTest?permits=3&lockManagerName=${encodeURIComponent(paramInput)}&lockManagerPermitCount=2`;
+
+      fetch(fluxUrl)
+      .then(response => response.json())
+      .then(data => {
+    	  data.forEach(item => {
+        document.getElementById('fluxResult').value = JSON.stringify(data, null, 2);
+    	  });
+      })
+      .catch(error => {
+        console.error('Error calling Flux API:', error);
+      });
+    }
+  </script>
+
+</body>
+</html>

--- a/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/common/Constants.java
+++ b/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/common/Constants.java
@@ -3,14 +3,11 @@ package edu.vandy.lockmanager.common;
 /**
  * Constants shared by the client and server components.
  */
-public class Constants {
-    public static final String SERVER_BASE_URL = "http://localhost:8080";
+public interface Constants {
+	String SERVER_BASE_URL = "http://localhost:8080";
 
-    public static class Endpoints {
-        public static final String CREATE = "create";
-        public static final String ACQUIRE_LOCK = "acquireLock";
-        public static final String ACQUIRE_LOCKS = "acquireLocks";
-        public static final String RELEASE_LOCK = "releaseLock";
-        public static final String RELEASE_LOCKS = "releaseLocks";
-    }
+	public interface Endpoints {
+		String CREATE = "create", ACQUIRE_LOCK = "acquireLock", ACQUIRE_LOCKS = "acquireLocks",
+				RELEASE_LOCK = "releaseLock", RELEASE_LOCKS = "releaseLocks", ACQUIRE_LOCKS_TEST = "acquireLocksTest";
+	}
 }

--- a/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/common/LockManager.java
+++ b/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/common/LockManager.java
@@ -3,76 +3,71 @@ package edu.vandy.lockmanager.common;
 import java.util.Objects;
 
 /**
- * This class is used to keep track of allocated {@link LockManager}
- * objects.
+ * This class is used to keep track of allocated {@link LockManager} objects.
  */
 public class LockManager {
-    /**
-     * The unique name of the {@link LockManager}.
-     */
-    public String name;
+	/**
+	 * The unique name of the {@link LockManager}.
+	 */
+	public String name;
 
-    /**
-     * The number of permits in this {@link LockManager}.
-     */
-    public Integer permitCount;
+	/**
+	 * The number of permits in this {@link LockManager}.
+	 */
+	public Integer permitCount;
 
-    /**
-     * @return The unique name of the {@link LockManager}
-     *
-    public String getName() {
-        return mName;
-    }
-    */
+	/**
+	 * @return The unique name of the {@link LockManager}
+	 *
+	 *         public String getName() { return mName; }
+	 */
 
-    /**
-     * Set the unique name of the {@link LockManager}.
-     *
-     * @param name The unique name of the {@link LockManager}
-     */
-    public LockManager(String name) {
-        this.name = name;
-    }
+	/**
+	 * Set the unique name of the {@link LockManager}.
+	 *
+	 * @param name The unique name of the {@link LockManager}
+	 */
+	public LockManager(String name) {
+		this.name = name;
+	}
 
-    public LockManager(String name,
-                       Integer permitCount) {
-        this.name = name + ":[" + permitCount + "]";
-    }
+	public LockManager(String name, Integer permitCount) {
+		this.name = name;
+		this.permitCount = permitCount;
+	}
 
-    /**
-     * This class needs a default constructor.
-     */
-    LockManager() {
-        name = "default";
-    }
+	/**
+	 * This class needs a default constructor.
+	 */
+	LockManager() {
+		name = "default";
+	}
 
-    /**
-     * @return A {@link String} representation
-     */
-    @Override
-    public String toString() {
-        return name;
-    }
+	/**
+	 * @return A {@link String} representation
+	 */
+	@Override
+	public String toString() {
+		return name + ":[" + permitCount + "]";
+	}
 
-    /**
-     * Overrides the {@code equals()} method to compare two {@link
-     * LockManager} objects based on their {@code name}.
-     *
-     * @param object The other {@link Object} to compare with this
-     *               object
-     * @return true if the object names are equal, false otherwise
-     */
-    @Override
-    public boolean equals(Object object) {
-        return object instanceof LockManager other
-            && this.name.equals(other.name);
-    }
+	/**
+	 * Overrides the {@code equals()} method to compare two {@link LockManager}
+	 * objects based on their {@code name}.
+	 *
+	 * @param object The other {@link Object} to compare with this object
+	 * @return true if the object names are equal, false otherwise
+	 */
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof LockManager other && this.name.equals(other.name);
+	}
 
-    /**
-     * @return A hash of the {@link LockManager} {@code name}
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(name);
-    }
+	/**
+	 * @return A hash of the {@link LockManager} {@code name}
+	 */
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
+	}
 }

--- a/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/configuration/VirtualThreadsConfiguration.java
+++ b/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/configuration/VirtualThreadsConfiguration.java
@@ -1,0 +1,37 @@
+package edu.vandy.lockmanager.configuration;
+
+import static org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME;
+
+import java.util.concurrent.Executors;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatProtocolHandlerCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.support.TaskExecutorAdapter;
+
+@Configuration
+@Profile("default")
+public class VirtualThreadsConfiguration {
+
+	/**
+	 * Configure the use of Java virtual threads to handle all incoming HTTP
+	 * requests.
+	 */
+	@Bean(APPLICATION_TASK_EXECUTOR_BEAN_NAME)
+	public AsyncTaskExecutor asyncTaskExecutor() {
+		return new TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor());
+	}
+
+	/**
+	 * Customize the ProtocolHandler on the TomCat Connector to use Java virtual
+	 * threads to handle all incoming HTTP requests.
+	 */
+	@Bean
+	public TomcatProtocolHandlerCustomizer<?> protocolHandlerVirtualThreadExecutorCustomizer() {
+		return protocolHandler -> protocolHandler.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
+
+	}
+
+}

--- a/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/server/LockManagerApplication.java
+++ b/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/server/LockManagerApplication.java
@@ -2,51 +2,16 @@ package edu.vandy.lockmanager.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.embedded.tomcat.TomcatProtocolHandlerCustomizer;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.core.task.AsyncTaskExecutor;
-import org.springframework.core.task.support.TaskExecutorAdapter;
-
-import java.util.concurrent.Executors;
-
-import static org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME;
 
 @SpringBootApplication
 @ComponentScan("edu.vandy.lockmanager")
 public class LockManagerApplication {
-    /**
-     * The main entry point into the LockManager microservice.
-     */
-    public static void main(String[] args) {
-        SpringApplication.run(LockManagerApplication.class,
-                              args);
-    }
+	/**
+	 * The main entry point into the LockManager microservice.
+	 */
+	public static void main(String[] args) {
+		SpringApplication.run(LockManagerApplication.class, args);
+	}
 
-    /**
-     * Configure the use of Java virtual threads to handle all
-     * incoming HTTP requests.
-     */
-    @Bean(APPLICATION_TASK_EXECUTOR_BEAN_NAME)
-    public AsyncTaskExecutor asyncTaskExecutor() {
-        return new TaskExecutorAdapter(Executors
-                                       .newVirtualThreadPerTaskExecutor());
-    }
-
-    /**
-     * Customize the ProtocolHandler on the TomCat Connector to
-     * use Java virtual threads to handle all incoming HTTP requests.
-     */
-    @Bean
-    public TomcatProtocolHandlerCustomizer<?> protocolHandlerVirtualThreadExecutorCustomizer() {
-        return protocolHandler -> {
-            protocolHandler
-                .setExecutor(Executors.newVirtualThreadPerTaskExecutor());
-        };
-    }
 }
-
-
-
-
-

--- a/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/server/LockManagerController.java
+++ b/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/server/LockManagerController.java
@@ -1,130 +1,143 @@
 package edu.vandy.lockmanager.server;
 
-import edu.vandy.lockmanager.common.Lock;
-import edu.vandy.lockmanager.common.LockManager;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
+import static edu.vandy.lockmanager.common.Constants.Endpoints.ACQUIRE_LOCK;
+import static edu.vandy.lockmanager.common.Constants.Endpoints.ACQUIRE_LOCKS;
+import static edu.vandy.lockmanager.common.Constants.Endpoints.ACQUIRE_LOCKS_TEST;
+import static edu.vandy.lockmanager.common.Constants.Endpoints.CREATE;
+import static edu.vandy.lockmanager.common.Constants.Endpoints.RELEASE_LOCK;
+import static edu.vandy.lockmanager.common.Constants.Endpoints.RELEASE_LOCKS;
+import static edu.vandy.lockmanager.utils.Utils.log;
 
 import java.util.List;
 
-import static edu.vandy.lockmanager.common.Constants.Endpoints.*;
-import static edu.vandy.lockmanager.utils.Utils.log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.vandy.lockmanager.common.Lock;
+import edu.vandy.lockmanager.common.LockManager;
+import edu.vandy.lockmanager.service.LockManagerService;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
- * This Spring {@code @RestController} defines methods that provide a
- * lock manager for a semaphore that can be shared amongst multiple
- * asynchronous Spring WebFlux clients.
+ * This Spring {@code @RestController} defines methods that provide a lock
+ * manager for a semaphore that can be shared amongst multiple asynchronous
+ * Spring WebFlux clients.
  */
 @RestController
+@CrossOrigin(origins = "*")
 public class LockManagerController {
-    /**
-     * Auto-wire the {@link LockManagerController} to the {@link
-     * LockManagerService}.
-     */
-    @Autowired
-    LockManagerService mService;
+	/**
+	 * Auto-wire the {@link LockManagerController} to the
+	 * {@link LockManagerService}.
+	 */
+	@Autowired
+	LockManagerService mService;
 
-    /**
-     * Initialize the {@link Lock} manager.
-     *
-     * @param permitCount The number of {@link Lock} objects to
-     *                    manage
-     * @return A {@link Mono} that emits the {@link LockManager}
-     *         associated with the state of the semaphore it manages
-     */
-    @GetMapping(CREATE)
-    public Mono<LockManager> create
-        (@RequestParam Integer permitCount) {
-        log("LockController.create()");
+	/**
+	 * Initialize the {@link Lock} manager.
+	 *
+	 * @param permitCount The number of {@link Lock} objects to manage
+	 * @return A {@link Mono} that emits the {@link LockManager} associated with the
+	 *         state of the semaphore it manages
+	 */
+	@GetMapping(CREATE)
+	public Mono<LockManager> create(@RequestParam Integer permitCount) {
+		log(Thread.currentThread().getStackTrace()[1].getMethodName());
 
-        return mService
-            // Forward to the service.
-            .create(permitCount);
-    }
+		return mService
+				// Forward to the service.
+				.create(permitCount);
+	}
 
-    /**
-     * Acquire a {@link Lock}.
-     *
-     * @param lockManager The {@link LockManager} that is associated
-     *         with the state of the semaphore it manages
-     * @return A {@link Mono} that emits an acquired {@link Lock}
-     */
-    @GetMapping(ACQUIRE_LOCK)
-    public Mono<Lock> acquire(@RequestParam LockManager lockManager) {
-        log("LockController.acquire()");
+	/**
+	 * Acquire a {@link Lock}.
+	 *
+	 * @param lockManager The {@link LockManager} that is associated with the state
+	 *                    of the semaphore it manages
+	 * @return A {@link Mono} that emits an acquired {@link Lock}
+	 */
+	@GetMapping(ACQUIRE_LOCK)
+	public Mono<Lock> acquire(@RequestParam LockManager lockManager) {
+		log(Thread.currentThread().getStackTrace()[1].getMethodName());
 
-        return mService
-            // Forward to the service.
-            .acquire(lockManager);
-    }
+		return mService
+				// Forward to the service.
+				.acquire(lockManager);
+	}
 
-    /**
-     * Acquire {@code permits} number of {@link Lock} objects.
-     *
-     * @param lockManager The {@link LockManager} that is associated
-     *         with the state of the semaphore it manages
-     * @param permits The number of permits to acquire
-     * @return A {@link Flux} that emits {@code permits} number of
-     *         acquired {@link Lock} objects
-     */
-    @GetMapping(ACQUIRE_LOCKS)
-    Flux<Lock> acquire(@RequestParam LockManager lockManager,
-                       Integer permits) {
-        log("LockController.acquire("
-                  + permits
-                  + ")");
+	/**
+	 * Acquire {@code permits} number of {@link Lock} objects.
+	 *
+	 * @param lockManager The {@link LockManager} that is associated with the state
+	 *                    of the semaphore it manages
+	 * @param permits     The number of permits to acquire
+	 * @return A {@link Flux} that emits {@code permits} number of acquired
+	 *         {@link Lock} objects
+	 */
+	@GetMapping(ACQUIRE_LOCKS)
+	Flux<Lock> acquire(@RequestParam LockManager lockManager, Integer permits) {
+		log(Thread.currentThread().getStackTrace()[1].getMethodName() + "(" + permits + ")");
 
-        return mService
-            // Forward to the service.
-            .acquire(lockManager, permits);
-    }
+		return mService
+				// Forward to the service.
+				.acquire(lockManager, permits);
+	}
 
-    /**
-     * Release the {@link Lock} so other clients can acquire it.
-     *
-     * @param lockManager The {@link LockManager} that is associated
-     *                    with the state of the semaphore it manages
-     * @param lock The {@link Lock} to release
-     * @return A {@link Mono} that emits {@link Boolean#TRUE} if
-     *         the {@link Lock} was released properly and
-     *         {@link Boolean#FALSE} otherwise.
-     */
-    @GetMapping(RELEASE_LOCK)
-    public Mono<Boolean> release(@RequestParam LockManager lockManager,
-                                 @RequestParam Lock lock) {
-        log("LockController.release("
-                  + lock
-                  + ")");
+	@GetMapping(ACQUIRE_LOCKS_TEST)
+	public Flux<Lock> acquireTest(@RequestParam String lockManagerName,
 
-        return mService
-            // Forward to the service.
-            .release(lockManager, lock);
-    }
+			@RequestParam Integer lockManagerPermitCount,
 
-    /**
-     * Release the {@code locks} so other clients can acquire them.
-     *
-     * @param lockManager The {@link LockManager} that is associated
-     *                    with the state of the semaphore it manages
-     * @param locks A {@link List} that contains {@link Lock} objects
-     *              to release
-     * @return A {@link Mono} that emits {@link Boolean#TRUE} if the
-     *         {@link Lock} was released properly and {@link
-     *         Boolean#FALSE} otherwise.
-     */
-    @PostMapping(RELEASE_LOCKS)
-    public Mono<Boolean> release
-        (@RequestParam LockManager lockManager,
-         @RequestBody List<Lock> locks) {
-        log("LockController.release("
-                  + locks
-                  + ")");
+			@RequestParam Integer permits) {
+		log(Thread.currentThread().getStackTrace()[1].getMethodName() + "(" + lockManagerName + ")" + "("
+				+ lockManagerPermitCount + ")" + "(" + permits + ")");
+		LockManager lockManager = new LockManager(lockManagerName, lockManagerPermitCount);
 
-        return mService
-            // Forward to the service.
-            .release(lockManager, locks);
-    }
+		return mService
+				// Forward to the service.
+				.acquire(lockManager, permits);
+	}
+
+	/**
+	 * Release the {@link Lock} so other clients can acquire it.
+	 *
+	 * @param lockManager The {@link LockManager} that is associated with the state
+	 *                    of the semaphore it manages
+	 * @param lock        The {@link Lock} to release
+	 * @return A {@link Mono} that emits {@link Boolean#TRUE} if the {@link Lock}
+	 *         was released properly and {@link Boolean#FALSE} otherwise.
+	 */
+	@GetMapping(RELEASE_LOCK)
+	public Mono<Boolean> release(@RequestParam LockManager lockManager, @RequestParam Lock lock) {
+		log(Thread.currentThread().getStackTrace()[1].getMethodName() + "(" + lock + ")");
+
+		return mService
+				// Forward to the service.
+				.release(lockManager, lock);
+	}
+
+	/**
+	 * Release the {@code locks} so other clients can acquire them.
+	 *
+	 * @param lockManager The {@link LockManager} that is associated with the state
+	 *                    of the semaphore it manages
+	 * @param locks       A {@link List} that contains {@link Lock} objects to
+	 *                    release
+	 * @return A {@link Mono} that emits {@link Boolean#TRUE} if the {@link Lock}
+	 *         was released properly and {@link Boolean#FALSE} otherwise.
+	 */
+	@PostMapping(RELEASE_LOCKS)
+	public Mono<Boolean> release(@RequestParam LockManager lockManager, @RequestBody List<Lock> locks) {
+		log(Thread.currentThread().getStackTrace()[1].getMethodName() + "(" + locks + ")");
+
+		return mService
+				// Forward to the service.
+				.release(lockManager, locks);
+	}
 }
-

--- a/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/service/LockManagerService.java
+++ b/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/service/LockManagerService.java
@@ -1,0 +1,22 @@
+package edu.vandy.lockmanager.service;
+
+import java.util.List;
+
+import edu.vandy.lockmanager.common.Lock;
+import edu.vandy.lockmanager.common.LockManager;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface LockManagerService {
+
+	Mono<LockManager> create(Integer permitCount);
+
+	Mono<Lock> acquire(LockManager lockManager);
+
+	Flux<Lock> acquire(LockManager lockManager, int permits);
+
+	Mono<Boolean> release(LockManager lockManager, List<Lock> locks);
+
+	Mono<Boolean> release(LockManager lockManager, Lock lock);
+
+}

--- a/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/service/impl/LockManagerServiceImpl.java
+++ b/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/service/impl/LockManagerServiceImpl.java
@@ -1,0 +1,271 @@
+package edu.vandy.lockmanager.service.impl;
+
+import static edu.vandy.lockmanager.utils.Utils.generateUniqueId;
+import static edu.vandy.lockmanager.utils.Utils.log;
+import static java.lang.Boolean.FALSE;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Service;
+
+import edu.vandy.lockmanager.common.Lock;
+import edu.vandy.lockmanager.common.LockManager;
+import edu.vandy.lockmanager.server.LockManagerController;
+import edu.vandy.lockmanager.service.LockManagerService;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * This Spring {@code Service} implements the {@link LockManagerController}
+ * endpoint handler methods using Spring WebFlux reactive types and a
+ * {@link Map} of {@link LockManager} objects associated with the
+ * {@link ArrayBlockingQueue} objects that store the state of each semaphore.
+ */
+@SuppressWarnings("BlockingMethodInNonBlockingContext")
+@Service
+class LockManagerServiceImpl implements LockManagerService {
+	/**
+	 * A {@link Map} that associates {@link LockManager} objects with the
+	 * {@link ArrayBlockingQueue} that stores the state of the semaphore.
+	 */
+	private final Map<LockManager, ArrayBlockingQueue<Lock>> mLockManagerMap = new ConcurrentHashMap<>();
+
+	/**
+	 * Initialize the {@link Lock} manager.
+	 *
+	 * @param permitCount The number of {@link Lock} objects to manage
+	 * @return A {@link Mono} that emits a {@link LockManager} uniquely identifying
+	 *         this semaphore
+	 */
+	public Mono<LockManager> create(Integer permitCount) {
+		return Mono.fromSupplier(() -> {
+			var availableLocks =
+					// Make an ArrayBlockQueue with "fair"
+					// semantics that limits concurrent access to
+					// the fixed number of available locks.
+					new ArrayBlockingQueue<Lock>(permitCount, true);
+
+			// Add each Lock to the queue.
+			availableLocks.addAll(makeLocks(permitCount));
+
+			// Create a new LockManager with a unique name.
+			var lockManager = new LockManager(generateUniqueId(), permitCount);
+
+			// Insert the new LockManager and the
+			// ArrayBlockingQueue into the Map.
+			mLockManagerMap.put(lockManager, availableLocks);
+
+			log("LockService.create(" + permitCount + ") " + "- made " + lockManager + " with locks = "
+					+ availableLocks);
+
+			// Return the new LockManager.
+			return lockManager;
+		});
+	}
+
+	/**
+	 * Create the requested number of {@link Lock} objects.
+	 *
+	 * @param count The number of {@link Lock} objects to create
+	 */
+	private List<Lock> makeLocks(int count) {
+		return IntStream
+				// Iterate from 0 to count - 1.
+				.range(0, count)
+
+				// Convert Integer to String.
+				.mapToObj(Integer::toString)
+
+				// Create a new Lock.
+				.map(Lock::new)
+
+				// Convert the Stream to a List.
+				.toList();
+	}
+
+	/**
+	 * Acquire a {@link Lock}, blocking until one is available, but return a
+	 * {@link Mono} so the caller needn't block.
+	 *
+	 * @param lockManager The {@link LockManager} that is associated with the state
+	 *                    of the semaphore it manages
+	 * @return A {@link Mono} that emits a {@link Lock}
+	 */
+	public Mono<Lock> acquire(LockManager lockManager) {
+		log("LockService.acquire() on " + lockManager);
+
+		return Mono
+				// Acquire an available lock, which may block.
+				.fromCallable(() -> {
+					log("LockService - requesting a Lock");
+
+					// Find the current state of the semaphore
+					// associated with lockManager.
+					var availableLocks = mLockManagerMap.get(lockManager);
+
+					if (availableLocks == null)
+						throw new IllegalArgumentException(lockManager.name);
+					else {
+						var lock = availableLocks.poll();
+
+						if (lock != null)
+							log("LockService - obtained Lock non-blocking " + lock);
+						else {
+							// This call can block since it runs in a
+							// virtual thread.
+							lock = availableLocks.take();
+
+							log("LockService - obtained Lock blocking " + lock);
+						}
+
+						// Return the Lock.
+						return lock;
+					}
+				})
+				// Display any exception that might occur.
+				.doOnError(exception -> log("LockService error - " + exception.getMessage()))
+				.doOnSuccess(mono -> log("LockService - returning Mono"));
+	}
+
+	/**
+	 * Acquire {@code permits} number of {@link Lock} objects.
+	 *
+	 * @param lockManager The {@link LockManager} that is associated with the state
+	 *                    of the semaphore it manages
+	 * @param permits     The number of permits to acquire
+	 * @return A {@link Flux} that emits {@code permits} newly acquired {@link Lock}
+	 *         objects
+	 */
+	public Flux<Lock> acquire(LockManager lockManager, int permits) {
+		log("LockService.acquire(" + permits + ")");
+
+		// Find the current state of the semaphore associated with
+		// lockManager.
+		var availableLocks = mLockManagerMap.get(lockManager);
+
+		if (availableLocks == null)
+			throw new IllegalArgumentException(lockManager.name);
+		else {
+			// Create a List to hold the acquired Lock objects.
+			List<Lock> acquiredLocks = new ArrayList<>(permits);
+
+			var flux = Mono
+					// Create a Mono that executes tryAcquireLock() method
+					// and emits its result.
+					.fromSupplier(() -> tryAcquireLock(availableLocks, acquiredLocks))
+
+					// Repeat the Mono indefinitely.
+					.repeat()
+
+					// Take elements from the stream until the number of
+					// acquired locks is equal to 'permits'.
+					.takeUntil(result -> result.equals(permits))
+
+					// Log the results.
+					.doOnNext(result -> {
+						if (result == permits)
+							log("LockService.acquire(" + permits + ") = " + result);
+					})
+					// Transform Flux<Integer> to Flux<Lock> that emits
+					// the acquired Lock objects as individual elements.
+					.thenMany(Flux.fromIterable(acquiredLocks));
+
+			log("LockService.acquire(" + permits + ") returning Flux");
+			return flux;
+		}
+	}
+
+	/**
+	 * This helper method tries to acquire a {@link Lock}.
+	 *
+	 * @param availableLocks Contains the state of the semaphore
+	 * @param acquiredLocks  The {@link List} of {@link Lock} objects we're trying
+	 *                       to acquire
+	 * @return The number of {@link Lock} objects in {@code
+	 *         acquiredLocks}
+	 */
+	private Integer tryAcquireLock(ArrayBlockingQueue<Lock> availableLocks, List<Lock> acquiredLocks) {
+		// Perform a non-blocking poll().
+		var lock = availableLocks.poll();
+
+		if (lock != null) {
+			// Add the acquired lock to the List.
+			acquiredLocks.add(lock);
+
+			// Return the number of acquired locks.
+			return acquiredLocks.size();
+		} else {
+			// Not enough locks are available, so release the acquired
+			// locks.
+			acquiredLocks
+					// offer() does not block.
+					.forEach(availableLocks::offer);
+
+			// Clear out the acquiredLocks List.
+			acquiredLocks.clear();
+
+			// Indicate we need to restart from the beginning.
+			return 0;
+		}
+	}
+
+	/**
+	 * Release the {@link Lock}.
+	 *
+	 * @param lockManager The {@link LockManager} that is associated with the state
+	 *                    of the semaphore it manages
+	 * @param lock        The {@link Lock} to release
+	 * @return A {@link Mono} that emits {@link Boolean#TRUE} if the {@link Lock}
+	 *         was released properly and {@link Boolean#FALSE} otherwise.
+	 */
+	public Mono<Boolean> release(LockManager lockManager, Lock lock) {
+		log("LockService.release([" + lock + "]) on " + lockManager);
+
+		// Try to get the locks associated with the lockManager.
+		var availableLocks = mLockManagerMap.get(lockManager);
+
+		if (availableLocks == null)
+			return Mono.just(FALSE);
+		return Mono
+				// Put the lock back into mAvailableQueue w/out blocking.
+				.just(availableLocks.offer(lock));
+	}
+
+	/**
+	 * Release the {@code locks}.
+	 *
+	 * @param lockManager The {@link LockManager} that is associated with the state
+	 *                    of the semaphore it manages
+	 * @param locks       A {@link List} that contains {@link Lock} objects to
+	 *                    release
+	 * @return A {@link Mono} that emits {@link Boolean#TRUE} if the {@link Lock}
+	 *         was released properly and {@link Boolean#FALSE} otherwise.
+	 */
+	public Mono<Boolean> release(LockManager lockManager, List<Lock> locks) {
+		log("LockService.release(" + locks.size() + ") " + locks + " on " + lockManager);
+
+		// Try to get the locks associated with lockManager.
+		var availableLocks = mLockManagerMap.get(lockManager);
+
+		if (availableLocks == null)
+			return Mono.just(FALSE);
+		else {
+			boolean allReleased = locks
+					// Convert List to a Stream.
+					.stream()
+
+					// Return true if all locks are put back into
+					// mAvailableLocks successfully (does not block).
+					.allMatch(availableLocks::offer);
+
+			return Mono
+					// Return the result, either true or false.
+					.just(allReleased);
+		}
+	}
+}

--- a/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/utils/Utils.java
+++ b/WebFlux/ex1/src/main/java/edu/vandy/lockmanager/utils/Utils.java
@@ -1,18 +1,21 @@
 package edu.vandy.lockmanager.utils;
 
 import java.util.UUID;
+import java.util.logging.Logger;
 
-public class Utils {
-    public static void log(String text) {
-        var thread = Thread.currentThread(); //.threadId();
-        System.out.println(text
-            + " [" + thread + "]: ");
-    }
+public interface Utils {
 
-    /**
-     * @return A unique {@link String} id
-     */
-    public static String generateUniqueId() {
-        return UUID.randomUUID().toString();
-    }
+	Logger logger = Logger.getLogger(Utils.class.getName());
+
+	static void log(String text) {
+		var thread = Thread.currentThread(); // .threadId();
+		logger.info(text + " [" + thread + "]: ");
+	}
+
+	/**
+	 * @return A unique {@link String} id
+	 */
+	static String generateUniqueId() {
+		return UUID.randomUUID().toString();
+	}
 }


### PR DESCRIPTION
- .gitignore: added entries for .gitignore file for Eclipse projects to ensure temporary files, build files and project settings are not added to repository commits.
About x1 project:
- callerpage.html added to test and call the APIs after run on localhost
- Constants(class to interface) file needs, to be completed, a private constructor to hide the implicit public one so in general for this use case is better using an interface which fields are all implicitly "public static final", and no impact on callers
- Previous LockManager contructor seemed ignoring the field permitCount, it was not assigned to instance field permitCount 
- moved the configuration beans from LockManagerApplication to VirtualThreadsConfiguration so if the app is launched with any other profile different from "default" it does not use Virtual Threads so the same app can be used easily to compare performances and differences between platform and Virtual threads
- to LockManagerController was added the @CrossOrigin(origins = "*") and the API acquireTest, to permit HTML/Js test
- LockManagerService became an interface and LockManagerServiceImpl its concrete class, this for many reasons: Abstraction and Decoupling, Flexibility and Switching Implementations, Mocking and Testing, Dependency Inversion Principle, Encourages Single Responsibility Principle, AOP (Aspect-Oriented Programming, Better Collaboration Between Teams, Enhanced Code Readability. By injecting interfaces instead of classes, the design is modular, flexible, and adherent to key software design principles, contributing to a more maintainable and scalable codebase, Reducing the visibility of classes and exposing only necessary interfaces, interface proxy uses Java Proxy Creation so this is supported by the Java platform while concrete class uses an external library for ByteCode which is highly dependent on the version of the Java, the UML Component Diagram are much clearer because they place a lot of emphasis on the concept of interface  .
- Utils class chenged to interface as Utility classes need, to be completed, a private constructor to hide the implicit public one so in general for this use case is better using an interface with static methods. A logger is better than System.out for many reasons and no impact on callers
- Multistage DockerFile added